### PR TITLE
chore: add metrics for frags processed by op-node

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -150,6 +150,11 @@ type Metrics struct {
 	// ProtocolVersions is pseudo-metric to report the exact protocol version info
 	ProtocolVersions *prometheus.GaugeVec
 
+	// Based metrics
+	BasedNewFrag               prometheus.Counter
+	BasedSealFrag              prometheus.Counter
+	BasedLastBlockWithAllFrags prometheus.Gauge
+
 	registry *prometheus.Registry
 	factory  metrics.Factory
 }
@@ -391,6 +396,23 @@ func NewMetrics(procName string) *Metrics {
 			"engine",
 			"recommended",
 			"required",
+		}),
+
+		// Based metrics
+		BasedNewFrag: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "based_new_frag",
+			Help:      "Number of new frags inserted into the execution engine",
+		}),
+		BasedSealFrag: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "based_seal_frag",
+			Help:      "Number of seal frags inserted into the execution engine",
+		}),
+		BasedLastBlockWithAllFrags: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "based_last_block_with_all_frags",
+			Help:      "Block number of the last block with all frags inserted into the execution engine",
 		}),
 
 		AltDAMetrics: altda.MakeMetrics(ns, factory),

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"io"
 	gosync "sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -444,7 +445,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 
 	managedMode := false
 
-	n.preconfChannels = engine.StartPreconf(ctx, n.l2Source)
+	n.preconfChannels = engine.StartPreconf(ctx, n.l2Source, *n.metrics)
 
 	if cfg.Rollup.InteropTime != nil {
 		sys, err := cfg.InteropConfig.Setup(ctx, n.log, &n.cfg.Rollup, n.l1Source, n.l2Source, n.metrics)

--- a/op-node/rollup/engine/preconf.go
+++ b/op-node/rollup/engine/preconf.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -93,9 +94,10 @@ type PreconfState struct {
 	pendingSeals map[uint64]eth.SignedSeal
 	ctx          context.Context
 	e            ExecEngine
+	m            metrics.Metrics
 }
 
-func NewPreconfState(ctx context.Context, e ExecEngine) PreconfState {
+func NewPreconfState(ctx context.Context, e ExecEngine, m metrics.Metrics) PreconfState {
 	return PreconfState{
 		pendingEnvs:  make(map[uint64]eth.SignedEnv),
 		pendingFrags: make(map[FragIndex]eth.SignedNewFrag),
@@ -110,13 +112,14 @@ func NewPreconfState(ctx context.Context, e ExecEngine) PreconfState {
 		lastBlockPruned: 0,
 		ctx:             ctx,
 		e:               e,
+		m:               m,
 	}
 }
 
 // Builds the preconf channels and starts a concurrent preconf handler in a separate goroutine.
-func StartPreconf(ctx context.Context, e ExecEngine) PreconfChannels {
+func StartPreconf(ctx context.Context, e ExecEngine, m metrics.Metrics) PreconfChannels {
 	channels := NewPreconfChannels()
-	go preconfHandler(ctx, channels, e)
+	go preconfHandler(ctx, channels, e, m)
 	return channels
 }
 
@@ -150,10 +153,12 @@ func (s *PreconfState) putFrag(sFrag *eth.SignedNewFrag) {
 	if isFirst || previousSent {
 		s.lastFragSent.Set(idx)
 		s.e.NewFrag(s.ctx, sFrag)
+		s.m.BasedNewFrag.Inc()
 
 		// When a frag is sent we should check if the next is present or if the seal is present
 		if frag.IsLast {
 			s.lastBlockWithAllFrags.Set(idx.BlockNumber)
+			s.m.BasedLastBlockWithAllFrags.Set(float64(idx.BlockNumber))
 			nextSeal, ok := s.pendingSeals[idx.BlockNumber]
 			if ok {
 				delete(s.pendingSeals, idx.BlockNumber)
@@ -177,6 +182,8 @@ func (s *PreconfState) putSeal(sSeal *eth.SignedSeal) {
 	if s.lastBlockWithAllFrags.IsEqual(seal.BlockNumber) {
 		s.lastSealSent.Set(seal.BlockNumber)
 		s.e.SealFrag(s.ctx, sSeal)
+		s.m.BasedSealFrag.Inc()
+
 		// When we put a seal we should check if the env of the next is present.
 		nextEnv, ok := s.pendingEnvs[seal.BlockNumber+1]
 		if ok {
@@ -235,8 +242,8 @@ func (s *PreconfState) prune(currentBlock uint64) {
 // Listens for env, frag and seal events and updates the local state.
 // If the events are ready, they are sent to the engine api. If not, they are
 // saved in the local state as pending until they are.
-func preconfHandler(ctx context.Context, c PreconfChannels, e ExecEngine) {
-	state := NewPreconfState(ctx, e)
+func preconfHandler(ctx context.Context, c PreconfChannels, e ExecEngine, m metrics.Metrics) {
+	state := NewPreconfState(ctx, e, m)
 
 	for {
 		select {

--- a/op-node/rollup/engine/preconf_test.go
+++ b/op-node/rollup/engine/preconf_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
@@ -109,7 +110,7 @@ func seal() eth.SignedSeal {
 func TestInOrder(t *testing.T) {
 	// General setup
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block
 	e := env()
@@ -175,7 +176,7 @@ func TestInOrder(t *testing.T) {
 func TestFragSealOutOfOrder(t *testing.T) {
 	// General setup
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block. Same as the happy path.
 	e := env()
@@ -197,7 +198,7 @@ func TestFragSealOutOfOrder(t *testing.T) {
 func TestFragsOutOfOrder(t *testing.T) {
 	// General setup
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block. Same as the happy path.
 	e := env()
@@ -226,7 +227,7 @@ func TestFragsOutOfOrder(t *testing.T) {
 func TestSealBeforeLastFrag(t *testing.T) {
 	// General setup
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block
 	e := env()
@@ -264,7 +265,7 @@ func TestSealBeforeLastFrag(t *testing.T) {
 func TestEverythingOutOfOrderAllAtOnce(t *testing.T) {
 	// General setup
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block
 	e := env()
@@ -300,7 +301,7 @@ func TestEverythingOutOfOrderAllAtOnce(t *testing.T) {
 
 func TestPreconfGapSavedByL2Block(t *testing.T) {
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block
 	e := env()
@@ -364,7 +365,7 @@ func TestPreconfGapSavedByL2Block(t *testing.T) {
 
 func TestOldStuffIsPrunedAndNotSent(t *testing.T) {
 	var m MockEngine
-	state := NewPreconfState(context.Background(), &m)
+	state := NewPreconfState(context.Background(), &m, *metrics.NewMetrics("test"))
 
 	// Data for the first block
 	e := env()


### PR DESCRIPTION
Adds some simple metrics for processing of `based_` namespace calls, as well as `BasedLastBlockWithAllFrags `