### PR TITLE
feat(op-deployer): etherscan URL as CLI argument/env variable

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -25,6 +25,7 @@ const (
 	PrivateKeyFlagName       = "private-key"
 	IntentTypeFlagName       = "intent-type"
 	EtherscanAPIKeyFlagName  = "etherscan-api-key"
+	EtherscanUrlFlagName     = "etherscan-url"
 	InputFileFlagName        = "input-file"
 	ContractNameFlagName     = "contract-name"
 )
@@ -138,6 +139,12 @@ var (
 		EnvVars:  PrefixEnvVar("ETHERSCAN_API_KEY"),
 		Required: true,
 	}
+	EtherscanUrlFlag = &cli.StringFlag{
+		Name:     EtherscanUrlFlagName,
+		Usage:    "etherscan URL for contract verification. if empty, only mainnet & sepolia chain IDs supported.",
+		EnvVars:  PrefixEnvVar("ETHERSCAN_API_URL"),
+		Required: false,
+	}
 	InputFileFlag = &cli.StringFlag{
 		Name:    InputFileFlagName,
 		Usage:   "filepath of input file for command",
@@ -177,6 +184,7 @@ var VerifyFlags = []cli.Flag{
 	L1RPCURLFlag,
 	ArtifactsLocatorFlag,
 	EtherscanAPIKeyFlag,
+	EtherscanUrlFlag,
 	InputFileFlag,
 	ContractNameFlag,
 }

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -30,10 +30,20 @@ type Verifier struct {
 	numFailed   int
 }
 
-func NewVerifier(apiKey string, l1ChainID uint64, artifactsFS foundry.StatDirFs, l log.Logger, l1Client *ethclient.Client) (*Verifier, error) {
-	etherscanUrl, err := getAPIEndpoint(l1ChainID)
-	if err != nil {
-		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
+func NewVerifier(
+	apiKey string,
+	l1ChainID uint64,
+	artifactsFS foundry.StatDirFs,
+	l log.Logger,
+	l1Client *ethclient.Client,
+	etherscanUrl string,
+) (*Verifier, error) {
+	if len(etherscanUrl) == 0 {
+		var err error
+		etherscanUrl, err = getAPIEndpoint(l1ChainID)
+		if err != nil {
+			return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
+		}
 	}
 
 	etherscan := NewEtherscanClient(apiKey, etherscanUrl, rate.NewLimiter(rate.Limit(3), 2))
@@ -93,7 +103,8 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	}
 	l.Info("Downloaded artifacts", "path", artifactsFS)
 
-	v, err := NewVerifier(etherscanAPIKey, l1ChainId, artifactsFS, l, l1Client)
+	etherscanUrl := cliCtx.String(deployer.EtherscanUrlFlagName)
+	v, err := NewVerifier(etherscanAPIKey, l1ChainId, artifactsFS, l, l1Client, etherscanUrl)
 	if err != nil {
 		return fmt.Errorf("failed to create verifier: %w", err)
 	}


### PR DESCRIPTION
This PR edits op-deployer code, adding the capability to chose a custom Etherscan API URL, either using the --etherscan-url CLI argument, or the ETHERSCAN_API_URL environment variable.

The new argument is optional and when empty, the default behavior of chosing a default block explorer is preserved.
